### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main # Reemplaza con el nombre de tu rama principal si es diferente
 
+permissions:
+  contents: read
+  pages: write
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Seva41/Seva41.github.io/security/code-scanning/1](https://github.com/Seva41/Seva41.github.io/security/code-scanning/1)

To fix the issue, add a `permissions` key at the root level of the workflow or within the `jobs` block. Since this workflow involves deploying to GitHub Pages, the minimal required permissions are `contents: read` and `pages: write`. This ensures the workflow has sufficient permissions to read repository contents and deploy the site while adhering to the principle of least privilege.

The changes will be made to `.github/workflows/github-pages.yml`:
1. Add a `permissions` block at the root level, specifying `contents: read` and `pages: write`.
2. Ensure no other permissions are granted unless explicitly required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
